### PR TITLE
fix Socket.send not to try to send larger data than it actually can send

### DIFF
--- a/lwip-wrapper/tcpip.c
+++ b/lwip-wrapper/tcpip.c
@@ -176,6 +176,10 @@ void lwip_accept(struct tcp_pcb *pcb) {
   tcp_accept(pcb, accept_callback);
 }
 
+u16_t lwip_tcp_sndbuf(struct tcp_pcb *pcb) {
+  return tcp_sndbuf(pcb);
+}
+
 err_t lwip_send(struct tcp_pcb *pcb, u8_t *data, u16_t size) {
   err_t err = tcp_write(pcb, data, size, 1);
   if (err != ERR_OK) {

--- a/src/lwip.zig
+++ b/src/lwip.zig
@@ -21,6 +21,7 @@ const VTable = struct {
     lwip_tcp_bind: *const fn (pcb: *anyopaque, ipaddr: *anyopaque, port: i32) callconv(.C) i8 = lwip_tcp_bind,
     tcp_listen_with_backlog: *const fn (pcb: *anyopaque, backblog: u8) callconv(.C) ?*anyopaque = tcp_listen_with_backlog,
     lwip_accept: *const fn (pcb: *anyopaque) callconv(.C) void = lwip_accept,
+    lwip_tcp_sndbuf: *const fn (pcb: *anyopaque) callconv(.C) u16 = lwip_tcp_sndbuf,
     lwip_send: *const fn (pcb: *anyopaque, buf: *anyopaque, len: u16) callconv(.C) i8 = lwip_send,
     lwip_connect: *const fn (pcb: *anyopaque, ipaddr: *anyopaque, port: i32) callconv(.C) i8 = lwip_connect,
     tcp_shutdown: *const fn (pcb: *anyopaque, shut_rx: i32, shut_tx: i32) callconv(.C) i8 = tcp_shutdown,
@@ -37,6 +38,7 @@ extern fn lwip_set_fd(pcb: *anyopaque, fd_ptr: *i32) void;
 extern fn lwip_tcp_bind(pcb: *anyopaque, ipaddr: *anyopaque, port: i32) i8;
 extern fn tcp_listen_with_backlog(pcb: *anyopaque, backblog: u8) ?*anyopaque;
 extern fn lwip_accept(pcb: *anyopaque) void;
+extern fn lwip_tcp_sndbuf(pcb: *anyopaque) u16;
 extern fn lwip_send(pcb: *anyopaque, buf: *anyopaque, len: u16) i8;
 extern fn lwip_connect(pcb: *anyopaque, ipaddr: *anyopaque, port: i32) i8;
 extern fn tcp_shutdown(pcb: *anyopaque, shut_rx: i32, shut_tx: i32) i8;

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -95,9 +95,9 @@ pub const Stream = union(enum) {
         };
     }
 
-    pub fn write(self: *Self, buffer: []u8) Error!void {
+    pub fn write(self: *Self, buffer: []u8) Error!usize {
         return switch (self.*) {
-            Self.uart => uart.puts(buffer),
+            Self.uart => uart.write(buffer),
             Self.socket => |*sock| sock.send(buffer),
             Self.opened_file => @panic("unimplemented"),
             Self.dir => @panic("unimplemented"),

--- a/src/uart.zig
+++ b/src/uart.zig
@@ -41,3 +41,8 @@ pub fn puts(data: []const u8) void {
         putc(c);
     }
 }
+
+pub fn write(data: []const u8) usize {
+    puts(data);
+    return data.len;
+}

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -85,10 +85,10 @@ pub export fn fd_write(fd: i32, buf_iovec_addr: i32, vec_len: i32, size_addr: i3
     const buf = ioVecsToSlice(iovecs, heap.runtime_allocator) catch return WasiError.NOMEM;
     defer heap.runtime_allocator.free(buf);
 
-    s.write(buf) catch return WasiError.INVAL;
+    const len = s.write(buf) catch return WasiError.INVAL;
 
     const size_ptr = @as(*i32, @ptrFromInt(@as(usize, @intCast(size_addr)) + linear_memory_offset));
-    size_ptr.* = @as(i32, @intCast(buf.len));
+    size_ptr.* = @as(i32, @intCast(len));
 
     return WasiError.SUCCESS;
 }
@@ -423,8 +423,9 @@ pub export fn sock_send(fd: i32, buf_iovec_addr: i32, buf_len: i32, flags: i32, 
 
     const send_len_ptr = @as(*i32, @ptrFromInt(@as(usize, @intCast(send_len_addr)) + linear_memory_offset));
 
-    socket.send(buf) catch return WasiError.INVAL;
-    send_len_ptr.* = @as(i32, @intCast(buf.len));
+    const sent_len = socket.send(buf) catch return WasiError.INVAL;
+    log.debug.printf("WASI sock_send: sent {d} bytes\n", .{sent_len});
+    send_len_ptr.* = @as(i32, @intCast(sent_len));
 
     return WasiError.SUCCESS;
 }


### PR DESCRIPTION
In lwIP's `tcp_write()` function, it can't send data larger than `pcb->snd_buf`. If it try to do it, it returns `ERR_MEM`.

This PR fixes `Socket.send` function not to send data larger than `pcb->snd_buf`. If it is requested to do that, it only sends the first `pcb->snd_buf` bytes data.