### PR TITLE
handle root directory as `.`

### DIFF
--- a/scripts/build-fs.sh
+++ b/scripts/build-fs.sh
@@ -20,7 +20,8 @@ if [ ! -d $dir_path ]; then
 fi
 
 # archive the directory with ustar format
-tar -cf disk.tar --format=ustar $dir_path
+# note: the root path of the archive must be `.`
+tar -cf disk.tar --format=ustar -C $dir_path .
 echo "tar archive created"
 
 # check if llvm-objcopy is installed


### PR DESCRIPTION
Wasm applications only can access the relative path to the current directory. So the root directory should be `.`.