### PR TITLE
move disk.o and disk.tar to build/

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -76,7 +76,7 @@ pub fn build(b: *Build) !void {
         kernel.addObjectFile(Build.LazyPath{ .path = p });
     }
     if (fs_path_option) |_| {
-        kernel.addObjectFile(Build.LazyPath{ .path = "disk.o" });
+        kernel.addObjectFile(Build.LazyPath{ .path = "build/disk.o" });
     }
     kernel.addOptions("options", kernel_options);
     b.installArtifact(kernel);

--- a/scripts/build-fs.sh
+++ b/scripts/build-fs.sh
@@ -21,6 +21,7 @@ fi
 
 # archive the directory with ustar format
 # note: the root path of the archive must be `.`
+mkdir -p build
 tar -cf disk.tar --format=ustar -C $dir_path .
 echo "tar archive created"
 
@@ -32,5 +33,5 @@ then
 fi
 
 # convert the archive to binary
-llvm-objcopy -Ibinary -Oelf64-x86-64 disk.tar disk.o
+llvm-objcopy -Ibinary -Oelf64-x86-64 build/disk.tar build/disk.o
 echo "disk.o created"

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -7,8 +7,7 @@ const Stream = stream.Stream;
 
 const FILES_MAX: usize = 32;
 
-extern const _binary_disk_tar_start: [*]u8;
-extern const _binary_disk_tar_size: [*]u8;
+extern const _binary_build_disk_tar_start: [*]u8;
 
 pub var files: [FILES_MAX]RegularFile = undefined;
 pub var dirs: [FILES_MAX]Directory = undefined;
@@ -99,7 +98,7 @@ pub fn init() void {
     }
 
     log.debug.printf("FILES_MAX: {d}\n", .{FILES_MAX});
-    const disk_pointer = @as([*]u8, @ptrCast(&_binary_disk_tar_start));
+    const disk_pointer = @as([*]u8, @ptrCast(&_binary_build_disk_tar_start));
 
     var off: usize = 0;
     var i: usize = 0;


### PR DESCRIPTION
The generated files while build-process should be in `build/`.