### PR TITLE
fix notifyQueue to update queue_select before notifying

### DIFF
--- a/src/drivers/virtio/common.zig
+++ b/src/drivers/virtio/common.zig
@@ -502,6 +502,8 @@ pub fn VirtioMmioTransport(comptime DeviceConfigType: type) type {
         }
 
         pub fn notifyQueue(self: *Self, virtq: *Virtqueue) void {
+            self.common_config.queue_select = virtq.index;
+            @fence(std.builtin.AtomicOrder.SeqCst);
             const offset = self.notify_off_multiplier * self.common_config.queue_notify_off;
             const addr = self.notify + @as(usize, @intCast(offset));
             @as(*volatile u16, @ptrFromInt(addr)).* = virtq.index;


### PR DESCRIPTION
We should update `queue_select` to the index of the queue before notifying.