### PR TITLE
fix poll_one_off to return 0 bytes when the connection is closed

### DIFF
--- a/src/stream.zig
+++ b/src/stream.zig
@@ -131,7 +131,7 @@ pub const Stream = union(enum) {
         }
     }
 
-    pub fn bytesCanRead(self: *Self) usize {
+    pub fn bytesCanRead(self: *Self) ?usize {
         return switch (self.*) {
             Self.uart => 1,
             Self.socket => |*sock| sock.bytesCanRead(),
@@ -140,7 +140,7 @@ pub const Stream = union(enum) {
         };
     }
 
-    pub fn bytesCanWrite(self: *Self) usize {
+    pub fn bytesCanWrite(self: *Self) ?usize {
         return switch (self.*) {
             Self.uart => 1,
             Self.socket => |*sock| sock.bytesCanWrite(),


### PR DESCRIPTION
`poll_one_off` should return an event which shows it can read/write 0 bytes from/to fd when the connection is closed.

If not so, file descriptors of closed connections are not closed because the application cannot know the connections are closed.