### PR TITLE
virtio net: interrupt coalescing when sending packets

### DIFF
--- a/src/drivers/virtio/common.zig
+++ b/src/drivers/virtio/common.zig
@@ -530,6 +530,10 @@ pub fn VirtioMmioTransport(comptime DeviceConfigType: type) type {
         }
 
         pub fn notifyQueue(self: *Self, virtq: *Virtqueue) void {
+            if (virtq.not_notified_num_descs == 0) {
+                return;
+            }
+
             self.common_config.queue_select = virtq.index;
             @fence(std.builtin.AtomicOrder.SeqCst);
             const offset = self.notify_off_multiplier * self.common_config.queue_notify_off;

--- a/src/timer.zig
+++ b/src/timer.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const heap = @import("heap.zig");
 const interrupt = @import("interrupt.zig");
 const sync = @import("sync.zig");
+const net = @import("drivers/virtio/net.zig");
 
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
@@ -58,6 +59,8 @@ pub fn handleIrq(frame: *interrupt.InterruptFrame) void {
         }
     }
     timers.release();
+
+    net.flush();
 }
 
 pub fn init() void {


### PR DESCRIPTION
Like #37, this PR suppresses the number of VMExit when sending packets.

It also improves performance!