### PR TITLE
Not to set bit 8 in PML4E, PDPTE

### DIFF
--- a/src/boot.S
+++ b/src/boot.S
@@ -135,13 +135,13 @@ protected_mode:
 construct_page_table:
     // PML4: 0x00000000_00000000 (temporarily used in protected mode)
     lea edi, [__kernel_pml4]
-    lea eax, [__kernel_pdpt + 0x103] // Present, writable, global.
+    lea eax, [__kernel_pdpt + 0x003] // Present, writable.
     mov dword ptr [edi], eax
     mov dword ptr [edi + 4], 0
 
     // PDPT
     lea edi, [__kernel_pdpt]
-    lea eax, [__kernel_pd + 0x103] // Present, writable, global.
+    lea eax, [__kernel_pd + 0x003] // Present, writable.
     mov ecx, 4 // (# of PDPT entries)
 
 write_pdpt_entry:


### PR DESCRIPTION
This patch fixes crash in KVM-enabled AMD CPU.

As for Intel CPU, the 8th bit in PML4E is ignored. But as for AMD CPU, the 8th bit in PML4E Must Be Zero. Setting 8th bit in PML4E on AMD CPU causes crash.
We must not set the 8th bit in PML4E and PDPTE.

Reference
- Intel® 64 and IA-32 Architectures Software Developer’s Manual Vol.3, Figure 4-11
- AMD64 Architecture Programmer’s Manual Vol.3, Figure 5-20