### PR TITLE
lwip: set mac address from virtio net

### DIFF
--- a/lwip-wrapper/tcpip.c
+++ b/lwip-wrapper/tcpip.c
@@ -224,12 +224,8 @@ u16_t lwip_get_remote_port(struct tcp_pcb *pcb) {
   return pcb->remote_port;
 }
 
-void init(u32_t ip, u32_t subnet, u32_t gateway_ip) {
+void init(u32_t ip, u32_t subnet, u32_t gateway_ip, char macaddr[6]) {
     lwip_init();
-
-    // Specify MAC Address
-    // 52:54:0:12:34:56
-    unsigned char macaddr[] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};
 
     ip_addr_t ipaddr, netmask, gateway;
     ipaddr.addr = ip;

--- a/src/main.zig
+++ b/src/main.zig
@@ -44,7 +44,7 @@ export fn bspEarlyInit(boot_magic: u32, boot_params: u64) align(16) callconv(.C)
     }
     mem.init2();
     if (param.params.isNetworkEnabled()) {
-        tcpip.init(param.params.addr.?, param.params.subnetmask.?, param.params.gateway.?);
+        tcpip.init(param.params.addr.?, param.params.subnetmask.?, param.params.gateway.?, &virtio_net.virtio_net.mac_addr);
     }
     fs.init();
 

--- a/src/tcpip.zig
+++ b/src/tcpip.zig
@@ -321,7 +321,7 @@ fn wasiToLwipAddressType(t: wasi.AddressFamily) u8 {
     }
 }
 
-pub extern fn init(ip: u32, netmask: u32, gateway: u32) void;
+pub extern fn init(ip: u32, netmask: u32, gateway: u32, macaddr: *[6]u8) void;
 
 export fn transmit(addr: [*c]u8, size: u32) callconv(.C) void {
     const data = addr[0..size];


### PR DESCRIPTION
The mac address is hard-coded now.

This PR fixes so that it sets the mac address as the value from virtio net.