### PR TITLE
integration test: attach a test directory to test file system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,17 +17,6 @@ const BuildParams = struct {
     fn new(b: *Build) Self {
         var params = BuildParams{};
 
-        const test_option = b.option(bool, "test", "run tests");
-        if (test_option) |t| {
-            params.is_test = t;
-            if (t) {
-                createTestDir() catch unreachable;
-                params.dir_path = TEST_DIR_PATH;
-            }
-        } else {
-            params.is_test = false;
-        }
-
         const obj_path_option = b.option([]const u8, "app-obj", "object file of application");
         if (obj_path_option) |p| {
             params.obj_path = p;
@@ -48,6 +37,17 @@ const BuildParams = struct {
             params.dir_path = p;
         } else {
             params.dir_path = null;
+        }
+
+        const test_option = b.option(bool, "test", "run tests");
+        if (test_option) |t| {
+            params.is_test = t;
+            if (t) {
+                createTestDir() catch unreachable;
+                params.dir_path = TEST_DIR_PATH;
+            }
+        } else {
+            params.is_test = false;
         }
 
         return params;

--- a/scripts/build-fs.sh
+++ b/scripts/build-fs.sh
@@ -25,13 +25,6 @@ mkdir -p build
 tar -cf build/disk.tar --format=ustar -C $dir_path .
 echo "tar archive created"
 
-# check if llvm-objcopy is installed
-if ! command -v llvm-objcopy &> /dev/null
-then
-    echo "llvm-objcopy could not be found"
-    exit 1
-fi
-
 # convert the archive to binary
-llvm-objcopy -Ibinary -Oelf64-x86-64 build/disk.tar build/disk.o
+objcopy -Ibinary -Oelf64-x86-64 build/disk.tar build/disk.o
 echo "disk.o created"

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -94,6 +94,7 @@ fn oct2int(oct: []const u8, len: usize) u32 {
 pub fn init() void {
     // check if fs is enabled
     if (!options.has_fs) {
+        log.debug.print("file system is not attached\n");
         return;
     }
 

--- a/src/wasi.zig
+++ b/src/wasi.zig
@@ -665,7 +665,7 @@ fn testServerSocket(base: usize) bool {
         log.fatal.printf("sock_open failed: res={d}\n", .{@intFromEnum(res)});
         return false;
     }
-    if (!(fd1.* == 4)) {
+    if (!(fd1.* == 5)) {
         log.fatal.printf("sock_open failed: fd={d}\n", .{fd1.*});
         return false;
     }


### PR DESCRIPTION
To test the file system in the integration test, we need to attach a directory to the VM.

But `params.dir_path` is overwritten in the current implementation.

This PR fixes so that `params.dir_path` is correctly set as `TEST_DIR_PATH`.