### PR TITLE
integration test: show output of Mewz

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -7,7 +7,7 @@ cd $REPO_ROOT
 mkdir -p build/test
 (stty -echo; sleep 4; (sleep 0.5; echo q) | telnet localhost 1234) &
 (sleep 2; curl localhost:1234) &
-./scripts/run-qemu.sh > build/test/output.txt
+./scripts/run-qemu.sh | tee build/test/output.txt
 
 if ! grep -q "Integration test passed" build/test/output.txt; then
   echo "Integration Test FAILED!!"


### PR DESCRIPTION
We cannot see the output of Mewz when running the integration test.

This PR fixes it by using tee.