### PR TITLE
upgrade zig to 0.14

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
 RUN apt-get update && apt-get install -y cmake
 
 ARG LLVM_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.0/clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
-ARG ZIG_VERSION=zig-linux-x86_64-0.12.1
+ARG ZIG_VERSION=zig-linux-x86_64-0.14.0-dev.2540+f857bf72e
 
 ENV PATH="/usr/bin/zig:${PATH}"
 ENV PATH=/usr/local/llvm/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,4 +4,11 @@
 		"context": "..",
 		"dockerfile": "./Dockerfile"
 	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ziglang.vscode-zig"
+			]
+		}
+	},
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 iso_root/
 zig-out/
 zig-cache/
+.zig-cache/
 build/
 virtio-net.pcap
 disk.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/mewz-project/wasker:latest
 
-ARG ZIG_VERSION=zig-linux-x86_64-0.12.0-dev.1856+94c63f31f
+ARG ZIG_VERSION=zig-linux-x86_64-0.14.0-dev.2540+f857bf72e
 
 ENV PATH="/usr/bin/zig:${PATH}"
 

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -7,7 +7,7 @@ const Stream = stream.Stream;
 
 const FILES_MAX: usize = 200;
 
-extern const _binary_build_disk_tar_start: [*]u8;
+extern var _binary_build_disk_tar_start: [*]u8;
 
 pub var files: [FILES_MAX]RegularFile = undefined;
 pub var dirs: [FILES_MAX]Directory = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -23,22 +23,23 @@ const wasi = @import("wasi.zig");
 
 extern fn wasker_main() void;
 
-export fn bspEarlyInit(boot_magic: u32, boot_params: u64) align(16) callconv(.C) void {
-    _ = boot_magic;
+export fn bspEarlyInit(boot_magic: u32, boot_params: u32) align(16) callconv(.C) void {
     const bootinfo = @as(*multiboot.BootInfo, @ptrFromInt(boot_params));
     const cmdline = util.getString(bootinfo.cmdline);
 
+    x64.init();
     param.parseFromArgs(cmdline);
 
     uart.init();
     lapic.init();
     ioapic.init();
     picirq.init();
-    x64.init();
+    printBootinfo(boot_magic, bootinfo);
     timer.init();
     interrupt.init();
     mem.init(bootinfo);
     pci.init();
+    log.debug.print("pci init finish\n");
     if (param.params.isNetworkEnabled()) {
         virtio_net.init();
     }
@@ -75,4 +76,16 @@ export fn write(fd: i32, b: *const u8, count: usize) callconv(.C) isize {
         return @as(isize, @intCast(count));
     }
     return -1;
+}
+
+fn printBootinfo(magic: u32, bootinfo: *multiboot.BootInfo) void {
+    log.debug.print("=== bootinfo ===\n");
+    log.debug.printf("magic: {x}\n", .{magic});
+    log.debug.printf("bootinfo addr: {x}\n", .{@intFromPtr(bootinfo)});
+    log.debug.printf("flags: {b:0>8}\n", .{bootinfo.flags});
+    log.debug.printf("mmap_addr: {x}\n", .{bootinfo.mmap_addr});
+    log.debug.printf("mmap_length: {x}\n", .{bootinfo.mmap_length});
+    const boot_loader_name = @as([*]u8, @ptrFromInt(bootinfo.boot_loader_name))[0..20];
+    log.debug.printf("boot_loader_name: {s}\n", .{boot_loader_name});
+    log.debug.print("================\n");
 }

--- a/src/param.zig
+++ b/src/param.zig
@@ -16,9 +16,9 @@ pub var params = Params{};
 
 // TODO: Add tests
 pub fn parseFromArgs(args: []const u8) void {
-    var params_itr = std.mem.split(u8, args, " ");
+    var params_itr = std.mem.splitScalar(u8, args, ' ');
     while (params_itr.next()) |part| {
-        var kv = std.mem.split(u8, part, "=");
+        var kv = std.mem.splitScalar(u8, part, '=');
 
         const k = kv.next() orelse continue;
         const v = kv.next() orelse continue;
@@ -36,7 +36,7 @@ pub fn parseFromArgs(args: []const u8) void {
 }
 
 fn parseIp(ip_str: []const u8) void {
-    var parts = std.mem.split(u8, ip_str, "/");
+    var parts = std.mem.splitScalar(u8, ip_str, '/');
     const ip = parts.next() orelse @panic("invalid ip format");
     const subnet = parts.next() orelse @panic("invalid ip format");
     if (parts.next()) |_| {

--- a/src/pci.zig
+++ b/src/pci.zig
@@ -92,7 +92,7 @@ pub const Device = struct {
     const Self = @This();
 
     fn new(bus: u8, slot: u8, func: u8) (Allocator.Error || Error)!Self {
-        var config_buffer: [16]u32 align(8) = [16]u32{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        var config_buffer: [16]u32 align(16) = [16]u32{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         for (0..16) |i| {
             const config_value = readConfig(bus, slot, func, @as(u8, @intCast(i * 4)));
             config_buffer[i] = config_value;

--- a/src/rand.zig
+++ b/src/rand.zig
@@ -1,4 +1,4 @@
-const Random = @import("std").rand.Random;
+const Random = @import("std").Random;
 
 pub const X64Random = Random{
     .ptr = undefined,

--- a/src/x64.ld
+++ b/src/x64.ld
@@ -51,6 +51,8 @@ SECTIONS {
     .rodata : AT(ADDR(.rodata) - VMA_OFFSET) {
         *(.rodata);
         *(.rodata.*);
+        *(.lrodata);
+        *(.lrodata.*);
 
         . = ALIGN(4096);
         __cpu_local = .;
@@ -63,6 +65,8 @@ SECTIONS {
     .data : AT(ADDR(.data) - VMA_OFFSET) {
         *(.data);
         *(.data.*);
+        *(.ldata);
+        *(.ldata.*);
 
         *(.got*);
 
@@ -75,6 +79,8 @@ SECTIONS {
         __bss = .;
         *(.bss);
         *(.bss.*);
+        *(.lbss);
+        *(.lbss.*);
         __bss_end = .;
 
         /* The kernel page table (physical addresses). */

--- a/src/x64.zig
+++ b/src/x64.zig
@@ -4,7 +4,6 @@ pub const EFLAGS_IF = 0x00000200;
 
 pub fn init() void {
     enableSSE();
-    @fence(std.builtin.AtomicOrder.seq_cst);
     enableAVX();
 }
 


### PR DESCRIPTION
- upgrade zig to `0.14.0-dev.2540+f857bf72e`
- fix build.zig to compatible with the version
- remove `@fence` because it's removed from Zig's builtin functions
  - I believe it works without `@fence`...
- fix linker script to contain `.lbss`, `.ldata`, `.lrodata`
- fix initialization of memory to be compatible with Multiboot spec