### PR TITLE
chore: fix lwip remote url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/lwip"]
 	path = submodules/lwip
-	url = git@github.com:lwip-tcpip/lwip.git
+	url = https://github.com/lwip-tcpip/lwip.git
 [submodule "submodules/newlib"]
 	path = submodules/newlib
 	url = https://sourceware.org/git/newlib-cygwin.git


### PR DESCRIPTION
use https instead of ssh